### PR TITLE
fix: support Codex behavior output schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - 本地安装器在 GBK/ASCII 等控制台中安全转义不可编码的 validator 日志字符，避免校验通过后因输出编码崩溃。
 - 密钥扫描补充加密私钥、PGP 私钥、npm Token 与 GitLab Personal Access Token 类别，并覆盖当前发布树、完整 Git 历史和 Semgrep。
 - 普通 CI 中的仓库内前向证据检查明确降级为非权威一致性检查；Release 必须通过仓库外固定公钥的认证门禁。
+- 行为评测输出 Schema 改用 Codex 结构化输出支持的关键字子集，最终 evidence schema 继续负责唯一性约束。
 
 ### 移除
 

--- a/evals/schemas/behavior-output.schema.json
+++ b/evals/schemas/behavior-output.schema.json
@@ -28,7 +28,6 @@
     },
     "recordTypes": {
       "type": "array",
-      "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": ["StudyProfile", "ProgressSnapshot", "ReviewQueue"]
@@ -36,7 +35,6 @@
     },
     "evidenceTags": {
       "type": "array",
-      "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": ["[用户材料]", "[原创练习]", "[官方核验]", "[待核验]"]

--- a/tests/test_forward_evidence.py
+++ b/tests/test_forward_evidence.py
@@ -176,6 +176,22 @@ class ForwardEvidenceTests(unittest.TestCase):
         self.assertNotIn("expectedPrimary", behavior_context)
         self.assertNotIn("tests/", behavior_context)
 
+    def test_codex_output_schemas_avoid_unsupported_unique_items(self) -> None:
+        for name in (
+            "route-output.schema.json",
+            "behavior-output.schema.json",
+            "judge-output.schema.json",
+        ):
+            schema = load_json(REPO / "evals" / "schemas" / name)
+            stack = [schema]
+            while stack:
+                value = stack.pop()
+                if isinstance(value, dict):
+                    self.assertNotIn("uniqueItems", value, name)
+                    stack.extend(value.values())
+                elif isinstance(value, list):
+                    stack.extend(value)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- removes `uniqueItems` from the actor-facing behavior output schema because Codex structured outputs rejects that keyword
- keeps uniqueness enforcement in the final forward-evidence schema
- adds a recursive regression test covering every Codex output schema
- records the compatibility fix in the v1.1.0 changelog

## Root cause

The first real forward evaluation completed all 36 routing cases, then the first behavior request failed with `invalid_json_schema`: `uniqueItems` is not permitted for `recordTypes`. The same keyword was also present on `evidenceTags`.

## Impact

Behavior evaluation can now reach the model while the committed evidence remains strictly validated before signing and release.

## Validation

- `python -m unittest tests.test_forward_evidence -v`: 11/11 pass
- `python scripts/check.py --verify-system-evidence`: 65/65 pass
- Semgrep: 0 findings
- official plugin validator: pass
- official Skill validators: 12/12 pass