### PR TITLE
ci: require disabled cache in v1.2 evidence

### DIFF
--- a/ci/schemas/evidence-1.2.schema.json
+++ b/ci/schemas/evidence-1.2.schema.json
@@ -14,6 +14,7 @@
     "codex_version",
     "model",
     "service_tier",
+    "cache_mode",
     "route_summary",
     "behavior_summary",
     "route_results",
@@ -30,6 +31,7 @@
     "codex_version": {"type": "string", "minLength": 1},
     "model": {"type": "string", "minLength": 1},
     "service_tier": {"enum": ["fast", "flex"]},
+    "cache_mode": {"const": "disabled"},
     "route_summary": {"$ref": "#/$defs/summary"},
     "behavior_summary": {"$ref": "#/$defs/summary"},
     "route_results": {

--- a/tests/test_trusted_forward_attestation.py
+++ b/tests/test_trusted_forward_attestation.py
@@ -60,7 +60,7 @@ def build_evidence(repo: Path, schema_version: str, now: datetime) -> dict:
     behavior_cases = json.loads(
         (repo / "tests/behavior-cases.json").read_text(encoding="utf-8")
     )["cases"]
-    return {
+    evidence = {
         "schema_version": schema_version,
         "complete": True,
         "generated_at": now.isoformat().replace("+00:00", "Z"),
@@ -113,6 +113,9 @@ def build_evidence(repo: Path, schema_version: str, now: datetime) -> dict:
             for case in behavior_cases
         ],
     }
+    if schema_version == "1.2":
+        evidence["cache_mode"] = "disabled"
+    return evidence
 
 
 class TrustedForwardAttestationTests(unittest.TestCase):
@@ -225,6 +228,16 @@ class TrustedForwardAttestationTests(unittest.TestCase):
         unknown["schema_version"] = "9.9"
         with self.assertRaisesRegex(trusted.legacy.AuthenticationError, "unsupported"):
             trusted.validate_evidence(self.repo, unknown)
+
+    def test_v12_requires_disabled_cache_mode(self) -> None:
+        missing = json.loads(json.dumps(self.evidence))
+        missing.pop("cache_mode")
+        with self.assertRaisesRegex(trusted.legacy.AuthenticationError, "schema violation"):
+            trusted.validate_evidence(self.repo, missing)
+        enabled = json.loads(json.dumps(self.evidence))
+        enabled["cache_mode"] = "enabled"
+        with self.assertRaisesRegex(trusted.legacy.AuthenticationError, "schema violation"):
+            trusted.validate_evidence(self.repo, enabled)
 
     def test_pr_binding_rejects_wrong_event_head(self) -> None:
         self.sign()


### PR DESCRIPTION
## 变更

- 受保护的 evidence 1.2 Schema 现在强制 `cache_mode: disabled`
- 过渡测试同时覆盖缺失字段和启用缓存的拒绝路径
- evidence 1.1 的 36/12 兼容门禁保持不变

## 原因

v1.2 正式动态评测将从运行器到签名证据强制无缓存。可信 verifier 必须先在受保护 `main` 上接受并验证这个新字段，随后功能 PR 才能提交新的 60/24 签名证据。

## 验证

- `python -m unittest discover -s tests -p test_trusted_forward_attestation.py -v`：8/8
- `python -m unittest discover -s tests -p test_*.py -q`：76/76
- `git diff --check`