### PR TITLE
ci: transition required check to offline validation

### DIFF
--- a/.github/workflows/authenticated-forward-evidence.yml
+++ b/.github/workflows/authenticated-forward-evidence.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout trusted verifier from the protected base
+      - name: Checkout trusted gate from the protected base
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -35,19 +35,5 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
-      - name: Install trusted verifier dependency
-        run: python -m pip install --disable-pip-version-check jsonschema==4.25.1
-      - name: Verify detached signature with externally pinned signer
-        env:
-          ALLOWED_SIGNERS: ${{ vars.KAOYAN_FORWARD_EVAL_ALLOWED_SIGNERS }}
-        run: |
-          if [ -z "$ALLOWED_SIGNERS" ]; then
-            echo "KAOYAN_FORWARD_EVAL_ALLOWED_SIGNERS is not configured" >&2
-            exit 1
-          fi
-          printf '%s\n' "$ALLOWED_SIGNERS" > "$RUNNER_TEMP/kaoyan-forward-eval.allowed_signers"
-          python trusted/ci/trusted_forward_attestation.py verify \
-            --repo candidate \
-            --binding-mode pr \
-            --expected-head "${{ github.event.pull_request.head.sha }}" \
-            --allowed-signers "$RUNNER_TEMP/kaoyan-forward-eval.allowed_signers"
+      - name: Verify candidate with trusted offline gate
+        run: python trusted/ci/trusted_offline_gate.py --repo candidate

--- a/ci/trusted_offline_gate.py
+++ b/ci/trusted_offline_gate.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate untrusted plugin data without executing candidate code."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+SKILLS = {
+    "kaoyan-22408-planner",
+    "kaoyan-408-tutor",
+    "kaoyan-english2-coach",
+    "kaoyan-error-loop-coach",
+    "kaoyan-material-study-assistant",
+    "kaoyan-math2-coach",
+    "kaoyan-mock-exam-coach",
+    "kaoyan-official-info-researcher",
+    "kaoyan-past-paper-analyst",
+    "kaoyan-politics-coach",
+    "kaoyan-progress-diagnostician",
+    "kaoyan-review-executor",
+}
+REFERENCES = {
+    "capability-routing-contract.md",
+    "evidence-copyright-contract.md",
+    "notion-brain-contract.md",
+    "obsidian-brain-contract.md",
+    "portable-learning-records.md",
+    "portable-learning-records.schema.json",
+}
+ALLOWED = {
+    ".codex-plugin/plugin.json",
+    "assets/kaoyan-22408.svg",
+    *(f"references/{name}" for name in REFERENCES),
+    *(f"skills/{name}/SKILL.md" for name in SKILLS),
+    *(f"skills/{name}/agents/openai.yaml" for name in SKILLS),
+}
+REMOVED = {
+    "evals/run_forward_eval.py",
+    "evals/trusted_forward_eval.py",
+    "evals/verify_forward_evidence.py",
+    "ci/trusted_forward_attestation.py",
+    "tests/forward-eval-evidence.json",
+    "tests/forward-eval-attestation.json",
+    "tests/forward-eval-attestation.json.sig",
+}
+
+
+class GateError(RuntimeError):
+    pass
+
+
+def tree_digest(payloads: dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for name in sorted(payloads):
+        encoded = name.encode("utf-8")
+        payload = payloads[name]
+        digest.update(len(encoded).to_bytes(4, "big"))
+        digest.update(encoded)
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise GateError(f"invalid JSON data: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise GateError(f"JSON root must be an object: {path}")
+    return value
+
+
+def verify(repo: Path) -> None:
+    repo = repo.resolve()
+    if not repo.is_dir():
+        raise GateError("candidate repository is missing")
+    if any(path.is_symlink() for path in repo.rglob("*")):
+        raise GateError("candidate contains a symbolic link")
+    if any((repo / path).exists() for path in REMOVED):
+        raise GateError("candidate contains retired model-evaluation artifacts")
+
+    workflow = (repo / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    required = "python scripts/check.py --verify-system-evidence"
+    if required not in workflow:
+        raise GateError("CI does not invoke the offline quality gate")
+    forbidden = ("codex exec", "run_forward_eval.py", "forward-eval-evidence")
+    if any(marker in workflow for marker in forbidden):
+        raise GateError("CI still invokes retired model-evaluation machinery")
+
+    plugin = repo / "plugins/kaoyan-22408"
+    actual = {
+        path.relative_to(plugin).as_posix()
+        for path in plugin.rglob("*")
+        if path.is_file() or path.is_symlink()
+    }
+    if actual != ALLOWED:
+        raise GateError("plugin tree does not match the exact release allowlist")
+    payloads: dict[str, bytes] = {}
+    for relative in sorted(ALLOWED):
+        payload = (plugin / relative).read_bytes()
+        try:
+            payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise GateError(f"release file is not UTF-8: {relative}") from exc
+        if b"\r" in payload:
+            raise GateError(f"release file is not LF-only: {relative}")
+        payloads[relative] = payload
+
+    manifest = load_json(plugin / ".codex-plugin/plugin.json")
+    if manifest.get("name") != "kaoyan-22408" or not isinstance(manifest.get("version"), str):
+        raise GateError("plugin manifest identity or version is invalid")
+    skill_dirs = {path.name for path in (plugin / "skills").iterdir() if path.is_dir()}
+    if skill_dirs != SKILLS:
+        raise GateError("candidate does not contain exactly the 12 approved Skills")
+
+    evidence = load_json(repo / "tests/system-validator-evidence.json")
+    plugin_evidence = evidence.get("plugin")
+    if not isinstance(plugin_evidence, dict):
+        raise GateError("validator evidence plugin section is invalid")
+    if plugin_evidence.get("version") != manifest["version"]:
+        raise GateError("validator evidence version is stale")
+    if plugin_evidence.get("treeSha256") != tree_digest(payloads):
+        raise GateError("validator evidence tree hash is stale or tampered")
+    results = evidence.get("results")
+    if not isinstance(results, dict) or results.get("plugin") != {"passed": True, "exitCode": 0}:
+        raise GateError("plugin validator evidence did not pass")
+    skills = results.get("skills")
+    expected = {"passed": True, "exitCode": 0}
+    if not isinstance(skills, dict) or set(skills) != SKILLS:
+        raise GateError("Skill validator evidence coverage is incomplete")
+    if any(result != expected for result in skills.values()):
+        raise GateError("one or more Skill validator results did not pass")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        verify(args.repo)
+    except (GateError, OSError) as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        return 1
+    print("[OK] trusted offline candidate gate")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_release.py
+++ b/tests/test_ci_release.py
@@ -55,9 +55,7 @@ class ReleaseCiTests(unittest.TestCase):
         self.assertIn("pull_request_target:", workflow)
         self.assertIn("path: trusted", workflow)
         self.assertIn("path: candidate", workflow)
-        self.assertIn("trusted/ci/trusted_forward_attestation.py verify", workflow)
-        self.assertIn("--binding-mode pr", workflow)
-        self.assertIn("--expected-head", workflow)
+        self.assertIn("trusted/ci/trusted_offline_gate.py --repo candidate", workflow)
         self.assertNotIn("python candidate/", workflow)
         self.assertNotIn("pip install -r candidate/", workflow)
 
@@ -68,9 +66,9 @@ class ReleaseCiTests(unittest.TestCase):
         verifier_step = candidate_run_steps[0]
         self.assertEqual(
             verifier_step["name"],
-            "Verify detached signature with externally pinned signer",
+            "Verify candidate with trusted offline gate",
         )
-        self.assertIn("trusted/ci/trusted_forward_attestation.py", verifier_step["run"])
+        self.assertIn("trusted/ci/trusted_offline_gate.py", verifier_step["run"])
         self.assertIn("--repo candidate", verifier_step["run"])
         self.assertNotIn("working-directory", verifier_step)
         self.assertTrue(all("working-directory" not in step for step in steps))


### PR DESCRIPTION
该自动过渡尝试已关闭：旧 `authenticated-forward-evidence` 同时绑定 PR 的精确提交，因此任何修改检查实现的 PR 都无法自行满足旧检查。正确迁移方式是仓库管理员在分支规则中一次性移除该旧必需检查；v1.4 合并后仓库只使用离线 CI。