### PR TITLE
ci: add no-CLI manual release fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
       - "v*"
   pull_request:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Optional version tag to create and publish (for example v1.4.0)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -116,7 +121,9 @@ jobs:
 
   release:
     name: release
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     needs:
       - validate
       - windows
@@ -135,11 +142,20 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
-      - name: Require tag commit to be on protected main
-        run: git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
+      - name: Require release commit to be on protected main
+        env:
+          RELEASE_EVENT: ${{ github.event_name }}
+        run: |
+          if [[ "$RELEASE_EVENT" == "workflow_dispatch" ]]; then
+            test "$GITHUB_SHA" = "$(git rev-parse refs/remotes/origin/main)"
+          else
+            git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
+          fi
       - name: Require tag to match manifest version
         id: meta
-        run: python ci/release_metadata.py --expect-tag "$GITHUB_REF_NAME" --github-output "$GITHUB_OUTPUT"
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+        run: python ci/release_metadata.py --expect-tag "$RELEASE_TAG" --github-output "$GITHUB_OUTPUT"
       - name: Download verified Ubuntu artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -148,10 +164,18 @@ jobs:
       - name: Publish immutable GitHub Release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create "${{ steps.meta.outputs.tag }}"
-          "dist/${{ steps.meta.outputs.archive }}"
-          "dist/${{ steps.meta.outputs.checksum }}"
-          --verify-tag
-          --title "kaoyan-22408 ${{ steps.meta.outputs.tag }}"
-          --generate-notes
+          RELEASE_EVENT: ${{ github.event_name }}
+        run: |
+          args=(
+            "${{ steps.meta.outputs.tag }}"
+            "dist/${{ steps.meta.outputs.archive }}"
+            "dist/${{ steps.meta.outputs.checksum }}"
+            --title "kaoyan-22408 ${{ steps.meta.outputs.tag }}"
+            --generate-notes
+          )
+          if [[ "$RELEASE_EVENT" == "workflow_dispatch" ]]; then
+            args+=(--target "$GITHUB_SHA")
+          else
+            args+=(--verify-tag)
+          fi
+          gh release create "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - 12 个 Skills 通过公共路由契约条件式接入 Notion，不新增总控 Skill、MCP、后台服务或发布者数据库。
 - 发布门禁改为完全离线、可重复的静态验证、单元测试、安全扫描、官方 validator 与跨平台一致构建；不再要求登录 Codex CLI。
+- 增加 GitHub Actions 手动发布后备入口；无需本地 GitHub/Codex CLI 登录，且仍强制最新 `main`、manifest 标签匹配和完整跨平台门禁。
 - 保留 60 个路由和 36 个行为场景作为规则覆盖资产，验证其结构、路由、rubric 与 Schema 完整性，不再声称模型运行通过率。
 
 ### 移除

--- a/QUALITY_GATES.md
+++ b/QUALITY_GATES.md
@@ -21,3 +21,5 @@
 ## 发布含义
 
 通过自动门禁表示插件文件、规则、测试资产、安全边界和发布包满足仓库声明；不表示任何特定模型对所有自然语言输入都能稳定选择同一 Skill 或产生相同答案。模型行为仍受宿主版本、可用工具、上下文和用户输入影响。
+
+发布既可由与 manifest 版本一致的 `v*` 标签触发，也可在无法使用本地 GitHub/Codex CLI 登录时，从 GitHub Actions 的 `CI` 工作流对最新 `main` 手动输入该标签。手动入口不会绕过检查：`validate`、`windows` 和 `reproducible` 必须全部成功，且标签必须严格等于 `plugin.json.version` 派生值，之后工作流才创建标签和 Release。

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ python scripts/build_release.py
 
 发布门禁包括 60 个路由场景和 36 个行为场景的数量、ID、主责 Skill、最近邻冲突、rubric、Schema 与覆盖完整性检查。它验证规则和测试资产是否完整，但不声称这些场景已经由某个模型实际运行。语义体验可在 ChatGPT/Codex 新任务中人工抽查，不作为自动发布阻塞条件。
 
-CI 在 Windows 与 Ubuntu 分别执行同一离线门禁并构建发布包，随后要求两个 ZIP 字节一致。Tag workflow 只允许位于 `main` 历史中的、版本与 manifest 一致的 `v*` 标签发布。完整设计见 [离线质量门禁](QUALITY_GATES.md)。
+CI 在 Windows 与 Ubuntu 分别执行同一离线门禁并构建发布包，随后要求两个 ZIP 字节一致。通常由位于 `main` 历史中、版本与 manifest 一致的 `v*` 标签触发发布；没有可用的本地 GitHub/Codex CLI 登录时，也可在 GitHub Actions 的 `CI` 工作流中从最新 `main` 手动输入同一标签。两条路径都必须先通过完整门禁，手动路径才会创建标签与 Release。完整设计见 [离线质量门禁](QUALITY_GATES.md)。
 
 版本记录见 [CHANGELOG.md](CHANGELOG.md)。
 

--- a/tests/test_ci_release.py
+++ b/tests/test_ci_release.py
@@ -54,6 +54,21 @@ class ReleaseCiTests(unittest.TestCase):
             workflow,
         )
 
+    def test_manual_release_fallback_is_gated_and_manifest_bound(self) -> None:
+        workflow = (REPO / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn("release_tag:", workflow)
+        self.assertIn("inputs.release_tag != ''", workflow)
+        self.assertIn(
+            'test "$GITHUB_SHA" = "$(git rev-parse refs/remotes/origin/main)"',
+            workflow,
+        )
+        self.assertIn(
+            'python ci/release_metadata.py --expect-tag "$RELEASE_TAG"',
+            workflow,
+        )
+        self.assertIn('args+=(--target "$GITHUB_SHA")', workflow)
+        self.assertIn("args+=(--verify-tag)", workflow)
+
     def test_obsolete_authenticated_evidence_workflow_is_absent(self) -> None:
         self.assertFalse(
             (REPO / ".github/workflows/authenticated-forward-evidence.yml").exists()


### PR DESCRIPTION
## 变更

- 为 `CI` workflow 增加可选 `release_tag` 手动输入
- 仅允许从最新 `main` 创建与 manifest 版本一致的标签
- 手动发布仍依赖 Linux、Windows 离线门禁和跨平台字节一致构建
- 保留原有受保护 `v*` 标签发布路径
- 补充发布测试和维护文档

## 本地验证

- `python scripts/check.py --verify-system-evidence`
- 61 tests passed
- 12/12 Skill validators passed
- 60 routing + 36 behavior assets validated

该入口用于本地 GitHub/Codex CLI 无法登录时，通过 GitHub 网页 Actions 安全发布。